### PR TITLE
Skip the repetitive master branch build for a commit

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,10 @@
 name: PR build
 
-on: [ push, pull_request ]
+on:
+    pull_request:
+    push:
+        branches-ignore:
+            - master
 
 jobs:
     ubuntu-build:


### PR DESCRIPTION
## Purpose
This will leads to parallel build conflicts.

